### PR TITLE
Physically Showing the Retry Logic Process with new command /hoteldemo (invalid place used: "FAIL") in discord

### DIFF
--- a/src/commands/hoteldemo.js
+++ b/src/commands/hoteldemo.js
@@ -1,0 +1,32 @@
+
+//THIS FILE IS JUST A DEMO FOR PHYICALLY SHOWING THE API RETRIES IN DISCORD!!
+
+import { SlashCommandBuilder } from 'discord.js';
+import { getHotelOptionsRetryDemo } from '../helpers/hotels.js'; 
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName('hoteldemo')
+        .setDescription('Demo: Show API retry logic in action')
+        .addStringOption(option =>
+            option.setName('city')
+                  .setDescription('City code for demo')
+                  .setRequired(true)),
+    async execute(interaction) {
+        await interaction.deferReply();
+
+        const cityCode = interaction.options.getString('city').toUpperCase();
+
+        try {
+            const result = await getHotelOptionsRetryDemo({
+                cityCode,
+                retryCallback: async msg => await interaction.followUp(`${msg}`)
+            });
+
+            await interaction.editReply(`${result.message}`);
+        } catch (err) {
+            console.error('Hotel demo error:', err);
+            await interaction.editReply('Something went wrong in the demo.');
+        }
+    },
+};

--- a/src/helpers/hotels.js
+++ b/src/helpers/hotels.js
@@ -112,3 +112,22 @@ export async function getHotelOptions({ cityCode, checkIn, checkOut, adults }) {
         return { ok: false, message: 'Error communicating with Amadeus API.' };
     }
 }
+
+//THIS FUNCTION IS JUST FOR DEMO PURPOSES FOR BOT PROJECT TASK #6
+export async function getHotelOptionsRetryDemo({ cityCode, retryCallback }) {
+    const MAX_RETRIES = 2;
+    const BASE_DELAY = 500; // ms
+    let lastError;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            // force a fake API error to simulate retries
+            throw { response: { statusCode: 500 } };
+        } catch (err) {
+            lastError = err;
+            if (retryCallback) await retryCallback(`Retry attempt ${attempt + 1} failed for ${cityCode}`);
+            if (attempt === MAX_RETRIES) return { ok: false, message: `Demo finished: failed after ${MAX_RETRIES + 1} attempts` };
+            await new Promise(resolve => setTimeout(resolve, BASE_DELAY * (attempt + 1)));
+        }
+    }
+}


### PR DESCRIPTION
Added hoteldemo to physically show the retry logic for the API (for invalid entry of place, in this case FAIL was used as the place)