### PR TITLE
fix: normalize LA to LAX in tripBrief

### DIFF
--- a/src/helpers/tripBrief.js
+++ b/src/helpers/tripBrief.js
@@ -36,7 +36,8 @@ export async function getTripBrief({
   const ret = parseIsoDateUtc(returnDate);
   const tripLenDays = daysBetweenUtc(dep, ret);
 
-  const origin = (originAirport || process.env.DEFAULT_ORIGIN_IATA || "SEA").toUpperCase();
+  let origin = (originAirport || process.env.DEFAULT_ORIGIN_IATA || "SEA").toUpperCase();
+  if (origin === "LA") origin = "LAX";
 
   // Resolve codes for hotels/flights (best effort)
   const [cityCode, destAirport] = await Promise.all([


### PR DESCRIPTION
Normalizes shorthand origin "LA" to "LAX" inside tripBrief before calling flights helper.

Prevents “need 3-letter IATA code” errors when users type LA.

Small isolated change; no behavior change for valid 3-letter origins.